### PR TITLE
Fix code scanning alert no. 22: Overly permissive regular expression range

### DIFF
--- a/client/src/pages/dashboard/inventoryManagement/InventoryProductsPage.js
+++ b/client/src/pages/dashboard/inventoryManagement/InventoryProductsPage.js
@@ -46,7 +46,7 @@ useEffect(() => {
             let term;
 
             if(searchTerm!==null){
-                term = searchTerm.replace(/[^a-zA-Z0-9_ \d]/, '');
+                term = searchTerm.replace(/[^a-zA-Z\d_ ]/, '');
             }
 
             //const term = searchTerm;


### PR DESCRIPTION
Fixes [https://github.com/it21109126/ITP-Jiffy-Test/security/code-scanning/22](https://github.com/it21109126/ITP-Jiffy-Test/security/code-scanning/22)

To fix the problem, we need to remove the redundant `0-9` range from the regular expression on line 49. The `\d` character class already includes all digits from 0 to 9, so we can safely remove `0-9` without changing the functionality of the code.

- We will update the regular expression on line 49 to remove the `0-9` range.
- No additional methods, imports, or definitions are needed to implement this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
